### PR TITLE
Fix width of Kirstie Whitaker's picture

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@ html {
 .card {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
 }
+.card td img {
+  width: 200px;
+}
 
 .container {
   padding: 0 16px;
@@ -68,8 +71,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="https://raw.githubusercontent.com/WhitakerLab/WhitakerLabProjectManagement/master/Kirstie-Whitaker/pictures/Hindex_KirstieWhitaker.jpg" alt="Kirstie Whitaker">
+      <td>
+      		<img src="https://raw.githubusercontent.com/WhitakerLab/WhitakerLabProjectManagement/master/Kirstie-Whitaker/pictures/Hindex_KirstieWhitaker.jpg" alt="Kirstie Whitaker">
       </td>
       <td>
       <div class="container">
@@ -90,8 +93,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/martin_oreilly.jpg" alt="Martin O'Reilly">
+      <td>
+      		<img src="profile_pictures/martin_oreilly.jpg" alt="Martin O'Reilly">
       </td>
       <td>
       <div class="container">
@@ -121,7 +124,7 @@ html {
       </table>
     </div>
   </div>
-</div> 
+</div>
 
 <div class="section">
   <h1>Doctoral students</h1>
@@ -130,8 +133,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -151,8 +154,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -172,8 +175,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -196,8 +199,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -217,8 +220,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -238,8 +241,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -259,8 +262,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -271,7 +274,7 @@ html {
         <h3>About me</h3>
         <p>I got a bachelor and master degree in mathematical engineering at the Universite catholique de Louvain, Belgium.
           I studied also two years at the Ecole Centrale Paris for a double degree. </p>
-        
+
         <p>I am also a deep passionate in sports such as hockey, tennis, etc. </p>
       </div>
       </td>
@@ -283,8 +286,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -304,8 +307,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -325,8 +328,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -346,8 +349,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -367,8 +370,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -388,8 +391,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -398,8 +401,8 @@ html {
         <h3>Research interests</h3>
         <p class="research_interests">Variational Inference; Markov Chain Monte carlo sampling algorithms;</p>
         <h3>About me</h3>
-        <p>I completed a 4-year degree of Statistics at the Athens University of Economics and Business. 
-          I continued my studies in the same university and received my MSc degree in Statistics in September 2017. 
+        <p>I completed a 4-year degree of Statistics at the Athens University of Economics and Business.
+          I continued my studies in the same university and received my MSc degree in Statistics in September 2017.
           In October 2017 I joined the University of Cambridge as a first year PhD student in the Department of Medical Genetics.</p>
       </div>
       </td>
@@ -411,8 +414,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -432,8 +435,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -456,8 +459,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -477,8 +480,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -498,8 +501,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -519,8 +522,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -545,8 +548,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -566,8 +569,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -587,8 +590,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -608,8 +611,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -629,8 +632,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -650,8 +653,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -671,8 +674,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -692,8 +695,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -713,8 +716,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/nathancunn.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/nathancunn.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -740,8 +743,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -761,8 +764,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -782,8 +785,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -803,8 +806,8 @@ html {
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">
@@ -813,21 +816,22 @@ html {
         <h3>Research interests</h3>
         <p class="research_interests">Statistical Neurosceince; Machine Learning; Predictive Modelling; Reproducibility Study. </p>
         <h3>About me</h3>
-        <p>I am a third year PhD student at the CDT of Mathematics for Real-world Systems at University of Warwick. I am jointly supervised by Prof. Thomas Nichols and 
-          Prof. Jianfeng Feng. I am currently working on linking brain connectivity, demographics and behaviour using HCP data. 
-          I completed the MathSys MSc in 2015. Before University of Warwick, I obtained a MSc in Mathematical Finance at Loughborough University 
+        <p>I am a third year PhD student at the CDT of Mathematics for Real-world Systems at University of Warwick. I am jointly supervised by Prof. Thomas Nichols and
+          Prof. Jianfeng Feng. I am currently working on linking brain connectivity, demographics and behaviour using HCP data.
+          I completed the MathSys MSc in 2015. Before University of Warwick, I obtained a MSc in Mathematical Finance at Loughborough University
           and a BSc in Mathematics at Shandong University, China.</p>
       </div>
       </td>
+      </table>
     </div>
   </div>
-    
+
      <div class="row">
     <div class="card">
       <table>
       <tr>
-      <td width="200px">
-      		<img style="width:200px" src="profile_pictures/<image_name>.jpg" alt="Your name">
+      <td>
+      		<img src="profile_pictures/<image_name>.jpg" alt="Your name">
       </td>
       <td>
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ html {
       <table>
       <tr>
       <td width="200px">
-      		<img src="https://raw.githubusercontent.com/WhitakerLab/WhitakerLabProjectManagement/master/Kirstie-Whitaker/pictures/Hindex_KirstieWhitaker.jpg" alt="Kirstie Whitaker">
+      		<img style="width:200px" src="https://raw.githubusercontent.com/WhitakerLab/WhitakerLabProjectManagement/master/Kirstie-Whitaker/pictures/Hindex_KirstieWhitaker.jpg" alt="Kirstie Whitaker">
       </td>
       <td>
       <div class="container">


### PR DESCRIPTION
Kirstie's picture did not have the `style="width:200px"` attribute (as per the solution for issue #33), so is massive!

This is a quick fix, We should think about how we can set all images to the same width without requiring per-picture markup. I've opened issue #38 to look at making this more robust, but this PR should fix the width for Kirstie's photo.

Note that I failed to pick this up in my review of Kirstie's initial PR. I'd suggest we improve out review process to make it easier to catch this type of error in future. I've opened issue #40 to address this.